### PR TITLE
Parse from file

### DIFF
--- a/Cake.Json.Tests/Cake.Json.Tests.csproj
+++ b/Cake.Json.Tests/Cake.Json.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,6 +28,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/Cake.Json.Tests/Test.cs
+++ b/Cake.Json.Tests/Test.cs
@@ -68,6 +68,24 @@ namespace Cake.Json.Tests
             Assert.IsNotNull (testObject);
             Assert.AreEqual ("Testing", testObject.Name);
         }
+
+        [Test]
+        public void ParseFromString ()
+        {
+            var testObject = context.CakeContext.ParseJson(SERIALIZED_JSON);
+
+            Assert.IsNotNull (testObject);
+            Assert.AreEqual ("Testing", testObject.Value<string> ("Name"));
+        }
+
+        [Test]
+        public void ParseFromFile()
+        {
+            var testObject = context.CakeContext.ParseJsonFromFile("test.json");
+
+            Assert.IsNotNull(testObject);
+            Assert.AreEqual ("Testing", testObject.Value<string> ("Name"));
+        }
     }
 }
 

--- a/Cake.Json.Tests/packages.config
+++ b/Cake.Json.Tests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Cake.Core" version="0.7.0" targetFramework="net45" />
   <package id="Cake.Testing" version="0.7.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Cake.Json/JsonAliases.cs
+++ b/Cake.Json/JsonAliases.cs
@@ -82,6 +82,19 @@ namespace Cake.Json
         {
             return JObject.Parse (json);
         }
+
+        /// <summary>
+        /// Parses the file contents into a JObject.
+        /// </summary>
+        /// <returns>The JObject.</returns>
+        /// <param name="context">The context.</param>
+        /// <param name="filename">The filename to serialize from.</param>
+        [CakeMethodAlias]
+        [CakeNamespaceImport("Newtonsoft.Json.Linq")]
+        public static JObject ParseJsonFromFile(this ICakeContext context, FilePath filename)
+        {
+            return JObject.Parse (File.ReadAllText (filename.MakeAbsolute (context.Environment).FullPath));
+        }
     }
 }
 


### PR DESCRIPTION
The first commits adds a function ParseJsonFromFile that lets the user parse a JSON file instead of an in-memory string.

The second commit adds tests for both parser methods. For this to work, a reference to Netwonsoft.Json was needed in the test project; if you had deliberately left that out, I'll gladly remove that commit from this PR.