### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/Cake.Json.Tests/Cake.Json.Tests.csproj
+++ b/Cake.Json.Tests/Cake.Json.Tests.csproj
@@ -28,6 +28,14 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Cake.Testing, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.17.1\lib\net45\Cake.Testing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -35,12 +43,6 @@
     <Reference Include="System" />
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.7.0\lib\net45\Cake.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Testing">
-      <HintPath>..\packages\Cake.Testing.0.7.0\lib\net45\Cake.Testing.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Cake.Json.Tests/FakeContext.cs
+++ b/Cake.Json.Tests/FakeContext.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Cake.Core.IO;
 using Cake.Core;
-using System.Collections.Generic;
+using Cake.Core.Tooling;
 using Cake.Testing;
 
 namespace Cake.Json.Tests
@@ -28,7 +28,8 @@ namespace Cake.Json.Tests
             var processRunner = new ProcessRunner (environment, log);
             var registry = new WindowsRegistry ();
 
-            context = new CakeContext (fileSystem, environment, globber, log, args, processRunner, registry);
+            var tools = new ToolLocator(environment, new ToolRepository(environment), new ToolResolutionStrategy(fileSystem, environment, globber, new FakeConfiguration()));
+            context = new CakeContext (fileSystem, environment, globber, log, args, processRunner, registry, tools);
             context.Environment.WorkingDirectory = testsDir;
         }
 

--- a/Cake.Json.Tests/packages.config
+++ b/Cake.Json.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.7.0" targetFramework="net45" />
-  <package id="Cake.Testing" version="0.7.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Testing" version="0.17.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Cake.Json/Cake.Json.csproj
+++ b/Cake.Json/Cake.Json.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,12 +29,13 @@
     <DocumentationFile>bin\Release\Cake.Json.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.7.0\lib\net45\Cake.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Cake.Json/packages.config
+++ b/Cake.Json/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.7.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.