### PR TITLE
Dependency on Cake.Core is not required

### DIFF
--- a/Cake.Json.nuspec
+++ b/Cake.Json.nuspec
@@ -17,7 +17,6 @@
       <tags>Cake Script Build JSON</tags>
 
       <dependencies>
-         <dependency id="Cake.Core" version="0.7.0" />
          <dependency id="Newtonsoft.Json" version="7.0.1" />
       </dependencies>
    </metadata>


### PR DESCRIPTION
- This assembly will already be available when addin is executing.